### PR TITLE
Add bouncey-castle web service and deployment assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# Install Miniconda
+RUN curl -sSLo /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && bash /tmp/miniconda.sh -b -p /opt/conda \
+    && rm /tmp/miniconda.sh
+ENV PATH="/opt/conda/bin:${PATH}"
+
+COPY environment.yml /tmp/environment.yml
+RUN conda env create -f /tmp/environment.yml
+ENV PATH="/opt/conda/envs/bouncey-castle/bin:${PATH}"
+
+WORKDIR /app
+COPY . /app
+EXPOSE 8000
+
+CMD ["gunicorn", "-b", "0.0.0.0:8000", "app:app"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
 # bouncey-castle
-Simple service to bounce specified url content back to the requestor.
+
+Bouncey Castle is a tiny web service that "bounces" the content from another URL back to the requestor.
+
+## Features
+- Homepage explaining how to use the service
+- `bounc_url` parameter fetches and returns remote content
+- Optional `debug=1` parameter shows status, headers and the returned HTML in a toggleable view
+
+## Local development
+```bash
+conda env create -f environment.yml
+conda activate bouncey-castle
+python app.py
+```
+Visit [http://localhost:8000](http://localhost:8000).
+
+## Docker
+```bash
+docker build -t bouncey-castle .
+docker run -p 8000:8000 bouncey-castle
+```
+
+## AWS deployment
+1. Launch an EC2 instance with CloudFormation:
+   ```bash
+   aws cloudformation deploy \
+     --template-file infra/cloudformation.yaml \
+     --stack-name bouncey-castle \
+     --capabilities CAPABILITY_IAM \
+     --parameter-overrides KeyName=your-keypair
+   ```
+2. SSH to the instance and set `DOMAIN` then run `deploy.sh`:
+   ```bash
+   sudo DOMAIN=your.domain bash /opt/bouncey-castle/deploy.sh
+   ```
+
+## Route53 and certificates
+1. In Route53 create a hosted zone for your domain.
+2. Add an A record pointing to the EC2 instance public IP.
+3. If using a registered domain elsewhere, update the registrar with Route53 name servers.
+4. The deploy script installs Apache and uses Certbot to obtain a Let's Encrypt certificate which auto-renews via systemd timers.
+
+## Apache configuration
+The reverse proxy configuration is stored in `config/apache-bouncey-castle.conf` and routes HTTP/HTTPS traffic to the Gunicorn service running on port 8000.
+
+## Infrastructure as Code
+See `infra/cloudformation.yaml` for a reproducible AWS setup.
+
+## Example
+Bouncing a humorous image:
+```
+https://<your-domain>/?bounc_url=https://http.cat/418&debug=1
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,50 @@
+import logging
+
+import requests
+from flask import Flask, Response, render_template, request
+
+app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def is_truthy(value: str) -> bool:
+    return value.lower() in {"true", "1"}
+
+
+@app.route("/")
+def index():
+    target_url = request.args.get("bounc_url")
+    debug = request.args.get("debug", "false")
+    if not target_url:
+        return render_template("index.html")
+
+    headers = {}
+    body = ""
+    status_code = 200
+    error = None
+
+    try:
+        resp = requests.get(target_url, timeout=10)
+        headers = dict(resp.headers)
+        body = resp.content
+        status_code = resp.status_code
+    except Exception as exc:  # pragma: no cover - network issues
+        error = str(exc)
+        status_code = 500
+
+    if is_truthy(debug):
+        return render_template(
+            "debug.html",
+            target_url=target_url,
+            status_code=status_code,
+            headers=headers,
+            error=error,
+            body=body.decode("utf-8", errors="replace"),
+        )
+
+    resp_headers = {key: value for key, value in headers.items() if key.lower() != "content-length"}
+    return Response(body, status=status_code, headers=resp_headers)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/config/apache-bouncey-castle.conf
+++ b/config/apache-bouncey-castle.conf
@@ -1,0 +1,10 @@
+<VirtualHost *:80>
+    ServerName example.com
+
+    ProxyPreserveHost On
+    ProxyPass / http://127.0.0.1:8000/
+    ProxyPassReverse / http://127.0.0.1:8000/
+
+    ErrorLog ${APACHE_LOG_DIR}/bouncey-castle_error.log
+    CustomLog ${APACHE_LOG_DIR}/bouncey-castle_access.log combined
+</VirtualHost>

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="/opt/bouncey-castle"
+ENV_NAME="bouncey-castle"
+DOMAIN="${DOMAIN:-example.com}"
+
+if ! command -v conda >/dev/null 2>&1; then
+  curl -sSLo /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  bash /tmp/miniconda.sh -b -p /opt/conda
+  export PATH="/opt/conda/bin:$PATH"
+fi
+
+conda env create -f environment.yml || conda env update -f environment.yml
+
+mkdir -p "$REPO_DIR"
+cp -R . "$REPO_DIR"
+
+cp service/bouncey-castle.service /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable bouncey-castle.service
+systemctl restart bouncey-castle.service
+
+apt-get update
+apt-get install -y apache2 certbot python3-certbot-apache
+
+cp config/apache-bouncey-castle.conf /etc/apache2/sites-available/bouncey-castle.conf
+a2enmod proxy proxy_http ssl
+a2ensite bouncey-castle.conf
+systemctl reload apache2
+
+certbot --apache -d "$DOMAIN" -n --agree-tos --register-unsafely-without-email

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: bouncey-castle
+channels:
+  - defaults
+dependencies:
+  - python=3.10
+  - flask
+  - requests
+  - gunicorn
+  - pytest

--- a/infra/cloudformation.yaml
+++ b/infra/cloudformation.yaml
@@ -1,0 +1,54 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Deploy Bouncey Castle service on Ubuntu 22.04
+
+Parameters:
+  KeyName:
+    Type: AWS::EC2::KeyPair::KeyName
+    Description: Name of an existing KeyPair to enable SSH
+  UbuntuAmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id
+
+Resources:
+  BounceySecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Allow SSH and HTTP/S
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 22
+          ToPort: 22
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+
+  BounceyInstance:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: t3.micro
+      ImageId: !Ref UbuntuAmiId
+      SecurityGroupIds:
+        - !Ref BounceySecurityGroup
+      KeyName: !Ref KeyName
+      UserData: !Base64 |
+        #!/bin/bash
+        apt-get update
+        apt-get install -y git
+        cd /opt
+        git clone https://github.com/OWNER/bouncey-castle.git
+        cd bouncey-castle
+        bash deploy.sh
+
+Outputs:
+  InstanceId:
+    Description: Instance Id of the created EC2 instance
+    Value: !Ref BounceyInstance
+  PublicDNS:
+    Description: Public DNS of the instance
+    Value: !GetAtt BounceyInstance.PublicDnsName

--- a/service/bouncey-castle.service
+++ b/service/bouncey-castle.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Bouncey Castle web service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/bouncey-castle
+Environment="PATH=/opt/conda/envs/bouncey-castle/bin"
+ExecStart=/opt/conda/envs/bouncey-castle/bin/gunicorn -b 127.0.0.1:8000 app:app
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/debug.html
+++ b/templates/debug.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Debug Bouncey Castle</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    textarea { width: 100%; height: 300px; }
+    iframe { width: 100%; height: 300px; border: 1px solid #ccc; display: none; }
+  </style>
+  <script>
+    function toggle() {
+      const raw = document.getElementById('raw');
+      const frame = document.getElementById('frame');
+      if (raw.style.display === 'none') {
+        raw.style.display = 'block';
+        frame.style.display = 'none';
+      } else {
+        raw.style.display = 'none';
+        frame.style.display = 'block';
+      }
+    }
+  </script>
+</head>
+<body>
+  <h1>Debug info for {{ target_url }}</h1>
+  <h2>Status</h2>
+  <p>Status code: {{ status_code }}</p>
+  {% if error %}<p>Error: {{ error }}</p>{% endif %}
+  <h2>Headers</h2>
+  <pre>{{ headers | tojson(indent=2) }}</pre>
+  <button onclick="toggle()">Display raw / Render HTML</button>
+  <textarea id="raw">{{ body }}</textarea>
+  <iframe id="frame"></iframe>
+  <script>
+    document.getElementById('frame').srcdoc = document.getElementById('raw').value;
+  </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Bouncey Castle</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 40px; }
+    code { background: #f0f0f0; padding: 2px 4px; }
+  </style>
+</head>
+<body>
+  <h1>Welcome to Bouncey Castle</h1>
+  <p>This tiny service fetches the content from another URL and bounces it back to you.</p>
+  <h2>Usage</h2>
+  <p>Send a request to this service with a <code>bounc_url</code> query parameter:</p>
+  <pre>https://&lt;your-domain&gt;/?bounc_url=https://http.cat/404</pre>
+  <p>Add <code>debug=1</code> to see request details and the fetched HTML in a toggleable pane.</p>
+  <h2>Example</h2>
+  <p>Try bouncing a funny website: <a href="/?bounc_url=https://http.cat/418&debug=1">/ ?bounc_url=https://http.cat/418&amp;debug=1</a></p>
+  <h2>Source</h2>
+  <p>Find the code on <a href="https://github.com/OWNER/bouncey-castle">GitHub</a>.</p>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,24 @@
+import sys, os
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import app
+
+def test_homepage(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b'Bouncey Castle' in resp.data
+
+def test_bounce_example(client):
+    resp = client.get('/?bounc_url=https://example.com')
+    assert resp.status_code == 200
+
+
+def test_debug(client):
+    resp = client.get('/?bounc_url=https://example.com&debug=1')
+    assert b'Debug info' in resp.data
+
+import pytest
+
+@pytest.fixture
+def client():
+    with app.app.test_client() as client:
+        yield client


### PR DESCRIPTION
## Summary
- implement Flask bounce service with debug view
- add conda env, Dockerfile, and deployment script for Apache with certbot
- provide CloudFormation template and documentation for AWS and Route53 setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad6b68b6488331a27876bc01ffd814