### PR TITLE
Rename query parameter to bounce_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bouncey Castle is a tiny web service that "bounces" the content from another URL
 
 ## Features
 - Homepage explaining how to use the service
-- `bounc_url` parameter fetches and returns remote content
+- `bounce_url` parameter fetches and returns remote content
 - Optional `debug=1` parameter shows status, headers and the returned HTML in a toggleable view
 
 ## Local development
@@ -50,5 +50,5 @@ See `infra/cloudformation.yaml` for a reproducible AWS setup.
 ## Example
 Bouncing a humorous image:
 ```
-https://<your-domain>/?bounc_url=https://http.cat/418&debug=1
+https://<your-domain>/?bounce_url=https://http.cat/418&debug=1
 ```

--- a/app.py
+++ b/app.py
@@ -13,7 +13,7 @@ def is_truthy(value: str) -> bool:
 
 @app.route("/")
 def index():
-    target_url = request.args.get("bounc_url")
+    target_url = request.args.get("bounce_url")
     debug = request.args.get("debug", "false")
     if not target_url:
         return render_template("index.html")

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,11 +11,11 @@
   <h1>Welcome to Bouncey Castle</h1>
   <p>This tiny service fetches the content from another URL and bounces it back to you.</p>
   <h2>Usage</h2>
-  <p>Send a request to this service with a <code>bounc_url</code> query parameter:</p>
-  <pre>https://&lt;your-domain&gt;/?bounc_url=https://http.cat/404</pre>
+  <p>Send a request to this service with a <code>bounce_url</code> query parameter:</p>
+  <pre>https://&lt;your-domain&gt;/?bounce_url=https://http.cat/404</pre>
   <p>Add <code>debug=1</code> to see request details and the fetched HTML in a toggleable pane.</p>
   <h2>Example</h2>
-  <p>Try bouncing a funny website: <a href="/?bounc_url=https://http.cat/418&debug=1">/ ?bounc_url=https://http.cat/418&amp;debug=1</a></p>
+  <p>Try bouncing a funny website: <a href="/?bounce_url=https://http.cat/418&debug=1">/ ?bounce_url=https://http.cat/418&amp;debug=1</a></p>
   <h2>Source</h2>
   <p>Find the code on <a href="https://github.com/OWNER/bouncey-castle">GitHub</a>.</p>
 </body>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,12 +8,12 @@ def test_homepage(client):
     assert b'Bouncey Castle' in resp.data
 
 def test_bounce_example(client):
-    resp = client.get('/?bounc_url=https://example.com')
+    resp = client.get('/?bounce_url=https://example.com')
     assert resp.status_code == 200
 
 
 def test_debug(client):
-    resp = client.get('/?bounc_url=https://example.com&debug=1')
+    resp = client.get('/?bounce_url=https://example.com&debug=1')
     assert b'Debug info' in resp.data
 
 import pytest


### PR DESCRIPTION
## Summary
- rename `bounc_url` request argument to `bounce_url`
- update docs, template, and tests for new parameter name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad706a6f048331a9cb41b7adf0473f